### PR TITLE
Don't register same var twice.

### DIFF
--- a/spec/headers/simple.h
+++ b/spec/headers/simple.h
@@ -118,6 +118,17 @@ typedef struct {
 
 void just_some_struct_with_nest_2(struct_with_nest_2* handle);
 
+struct struct_foo {
+  struct struct_bar* bar;
+};
+
+struct struct_bar {
+  int x;
+};
+
+typedef struct struct_bar struct_bar;
+void some_struct_with_other_struct_pointer(struct_bar* handle);
+
 #define inet_pton __inet_pton
 int __inet_pton(int, char*, void*);
 

--- a/spec/lib_body_transformer_spec.cr
+++ b/spec/lib_body_transformer_spec.cr
@@ -232,4 +232,12 @@ describe LibBodyTransformer do
       OCTAL = 493
       HEXA = 65535
     )
+
+  assert_transform "simple",
+    "fun some_struct_with_other_struct_pointer", %(
+      struct StructBar
+        x : LibC::Int
+      end
+      fun some_struct_with_other_struct_pointer(handle : StructBar*)
+    )
 end

--- a/src/crystal_lib/parser.cr
+++ b/src/crystal_lib/parser.cr
@@ -150,7 +150,10 @@ class CrystalLib::Parser
 
     cursor.visit_children do |subcursor|
       if subcursor.kind == Clang::Cursor::Kind::FieldDecl
-        struct_or_union.fields << visit_var_declaration(subcursor)
+        var = visit_var_declaration(subcursor)
+        unless struct_or_union.fields.any?{ |v| v.name == var.name }
+          struct_or_union.fields << var
+        end
       end
 
       Clang::VisitResult::Continue


### PR DESCRIPTION
There is a problem that `struct.var` could be registered twice.
The minimum example is

```c
struct struct_foo { struct struct_bar* bar; };
struct struct_bar { int x; };
typedef struct struct_bar struct_bar;
```

In this case, visit_var_declaration is called twice about `struct_bar.x` on reference and definitioin.
Then, our parser produces as following.

```crystal
struct StructBar
  x : LibC::Int
  x : LibC::Int
end
```

This pr fixes it, and produces expected code.

```crystal
struct StructBar
  x : LibC::Int
end
```

Thanks.