### PR TITLE
Use IO::Memory instead of MemoryIO

### DIFF
--- a/src/crystal_lib/lib_transformer.cr
+++ b/src/crystal_lib/lib_transformer.cr
@@ -28,7 +28,7 @@ class CrystalLib::LibTransformer < Crystal::Transformer
   end
 
   def process_includes
-    headers = MemoryIO.new
+    headers = IO::Memory.new
     flags = [] of String
     prefixes = [] of String
     remove_prefix = true


### PR DESCRIPTION
This commit fixes this warning:

    Warning: MemoryIO is deprecated and will be removed after 0.20.0, use IO::Memory instead