### PR TITLE
quick partial fix for clang 3.9

### DIFF
--- a/src/clang/enums.cr
+++ b/src/clang/enums.cr
@@ -253,6 +253,8 @@ module Clang
       VariableArray       = 115
       DependentSizedArray = 116
       MemberPointer       = 117
+      Auto                = 118
+      Elaborated          = 119
     end
   end
 

--- a/src/crystal_lib/parser.cr
+++ b/src/crystal_lib/parser.cr
@@ -221,7 +221,8 @@ class CrystalLib::Parser
       else
         named_types[spelling]? || error_type(spelling)
       end
-    when Clang::Type::Kind::Unexposed
+    when Clang::Type::Kind::Unexposed,
+         Clang::Type::Kind::Elaborated
       existing = @cursor_hash_to_node[type.cursor.hash]?
       if existing
         NodeRef.new(existing)
@@ -257,7 +258,8 @@ class CrystalLib::Parser
          Clang::Type::Kind::WChar
       primitive_type(type.kind)
     when Clang::Type::Kind::Record,
-         Clang::Type::Kind::Dependent
+         Clang::Type::Kind::Dependent,
+         Clang::Type::Kind::Auto
       # Skip these for now. If they are needed we'll analyze them at that time
       error_type(type.spelling)
     else


### PR DESCRIPTION
Quick fix for #34 
Solving by treat Elaborated like Unexposed.
<del>However, for some struct ref as type in itself or some struct/enum ref as type before definition,
this fix won't work.
It seems that real fix need some recode.</del>