### PR TITLE
Add enumerated types support (#37)

### DIFF
--- a/src/crystal_lib/prefix_importer.cr
+++ b/src/crystal_lib/prefix_importer.cr
@@ -56,13 +56,24 @@ class CrystalLib::PrefixImporter
   end
 
   def process(node : Enum)
-    if node.name.empty?
+    if node.name.empty? # anonymous enum
       node.values.each do |value|
         name = match_prefix(value)
         next unless name
 
         @nodes << Crystal::Assign.new(Crystal::Path.new(@mapper.crystal_type_name(name)), Crystal::NumberLiteral.new(value.value))
       end
+    else # enumerated type
+      members = [] of Crystal::ASTNode
+
+      node.values.each do |value|
+        name = match_prefix(value)
+        next unless name
+
+        members << Crystal::Arg.new(@mapper.crystal_type_name(name), Crystal::NumberLiteral.new(value.value))
+      end
+
+      @nodes << Crystal::EnumDef.new(Crystal::Path.new(node.name), members)
     end
   end
 


### PR DESCRIPTION
Example:
```bash
$ cat <<'EOF' > mylib.h
enum MyEnumeratedType {
	MY_FIRST,
	MY_SECOND,
	MY_THIRD,
};
EOF

$ cat <<'EOF' > mylib.cr
@[Include("./mylib.h", prefix: %w(My MY_))]
lib MyLib
end
EOF

$ crystal src/main.cr -- mylib.cr 2>/dev/null
lib MyLib
  enum MyEnumeratedType
    First = 0
    Second = 1
    Third = 2
  end
end
```