### PR TITLE
Fix crystal type name with camelcased names

### DIFF
--- a/spec/headers/simple.h
+++ b/spec/headers/simple.h
@@ -48,7 +48,8 @@ enum some_enum_2 just_some_enum_2();
 
 enum some_enum_3 {
   node_para = 1,
-  NODE_LINK = 2
+  NODE_LINK = 2,
+  NodeName = 3
 };
 enum some_enum_3 just_some_enum_3();
 
@@ -100,6 +101,9 @@ void just_some_struct_with_end(struct struct_with_end* handle);
 
 typedef int __underscore;
 __underscore just_some_underscore();
+
+typedef int TCamelCase;
+TCamelCase just_some_camelcase();
 
 struct struct_with_nest {
   struct {

--- a/spec/lib_body_transformer_spec.cr
+++ b/spec/lib_body_transformer_spec.cr
@@ -119,18 +119,17 @@ describe LibBodyTransformer do
     )
 
   assert_transform "simple",
-    "fun just_some_enum_3", %(
-      enum SomeEnum3
-        NodePara = 1
-        NodeLink = 2
-      end
-      fun just_some_enum_3 : SomeEnum3
-    )
-
-  assert_transform "simple",
     "SOCK_STREAM = SOCK_STREAM\nSOCK_DGRAM = SOCK_DGRAM", %(
       SOCK_STREAM = 1
       SOCK_DGRAM = 2
+    )
+
+  assert_transform "simple",
+    "fun just_some_struct_1", %(
+      struct SomeStruct1
+        x : LibC::Int
+      end
+      fun just_some_struct_1 : SomeStruct1
     )
 
   assert_transform "simple",

--- a/spec/lib_body_transformer_spec.cr
+++ b/spec/lib_body_transformer_spec.cr
@@ -114,6 +114,7 @@ describe LibBodyTransformer do
       enum SomeEnum3
         NodePara = 1
         NodeLink = 2
+        NodeName = 3
       end
       fun just_some_enum_3 : SomeEnum3
     )
@@ -191,6 +192,12 @@ describe LibBodyTransformer do
     "fun just_some_underscore", %(
       alias X__Underscore = LibC::Int
       fun just_some_underscore : X__Underscore
+    )
+
+  assert_transform "simple",
+    "fun just_some_camelcase", %(
+      alias TCamelCase = LibC::Int
+      fun just_some_camelcase : TCamelCase
     )
 
   assert_transform "simple",

--- a/src/crystal_lib/type_mapper.cr
+++ b/src/crystal_lib/type_mapper.cr
@@ -241,7 +241,7 @@ class CrystalLib::TypeMapper
       name = name[underscore_index + 1..-1]
     end
 
-    name = name.downcase.camelcase
+    name = name.underscore.camelcase
 
     if underscore_index
       name = String.build do |str|


### PR DESCRIPTION
See #42 .


Example:
```bash
$ cat /tmp/test.h
typedef enum TSomeEnum
{
	TSomeValue,
	TSomeOtherValue,
} TSomeEnum;
enum TSomeEnum test();

$ cat test.cr
@[Include("/tmp/test.h", prefix: "test", remove_prefix: false)]
lib LibTest
end

$ crystal run src/main.cr -- test.cr
lib LibTest
  fun test : TSomeEnum
  enum TSomeEnum
    TSomeValue = 0
    TSomeOtherValue = 1
  end
end
```