### PR TITLE
Fix: CamelCased name w/ pointer to an opaque struct

### DIFF
--- a/spec/headers/simple.h
+++ b/spec/headers/simple.h
@@ -32,8 +32,11 @@ int some_int;
 fun_ptr some_fun_ptr;
 
 typedef struct opaque *opaque_reference;
+struct anotherOpaque;
+typedef struct anotherOpaque anotherOpaqueReference;
 
 opaque_reference just_opaque_reference();
+anotherOpaqueReference *just_another_opaque_reference();
 
 typedef enum {
   x,

--- a/spec/lib_body_transformer_spec.cr
+++ b/spec/lib_body_transformer_spec.cr
@@ -93,6 +93,12 @@ describe LibBodyTransformer do
     )
 
   assert_transform "simple",
+    "fun just_another_opaque_reference", %(
+      type AnotherOpaqueReference = Void*
+      fun just_another_opaque_reference : AnotherOpaqueReference
+    )
+
+  assert_transform "simple",
     "fun just_some_enum_1", %(
       enum SomeEnum1
         X = 0

--- a/src/crystal_lib/type_mapper.cr
+++ b/src/crystal_lib/type_mapper.cr
@@ -67,8 +67,7 @@ class CrystalLib::TypeMapper
 
     # Check the case of a pointer to an opaque struct
     if opaque_type = opaque_typedef?(pointee_type)
-      typedef_name = opaque_type.name.capitalize
-      return declare_typedef(typedef_name, pointer_type(path("Void")))
+      return declare_typedef(opaque_type.name, pointer_type(path("Void")))
     end
 
     pointer_type(map_non_recursive(type.type))


### PR DESCRIPTION
Such as in #42, typedef names of pointers to opaque structs like `SomeName` are transformed as `Somename` instead of `SomeName`.

Here is an example:
```bash
$ cat /tmp/test.h 
struct SomeOpaque;
typedef struct someOpaque someOpaqueReference;
someOpaqueReference *some_function();

$ cat test.cr 
@[Include("/tmp/test.h", prefix: ["some_"], remove_prefix: false)]
lib Test
end

$ crystal src/main.cr -- test.cr
lib Test
  fun function = some_function : Someopaquereference
  type Someopaquereference = Void*
end
```

With the patch:
```bash
$ crystal src/main.cr -- test.cr
lib Test
  fun function = some_function : SomeOpaqueReference
  type SomeOpaqueReference = Void*
end
```
  

_PS: I don't really get why the `capitalize` call was here since the `declare_typedef` function already handles this (maybe some code that was not updated after a refactoring ?), just let me know if this issue should be handled differently._