### PR TITLE
Add comments extraction support

### DIFF
--- a/examples/lib_git2.cr
+++ b/examples/lib_git2.cr
@@ -1,7 +1,8 @@
 @[Include(
   "git2.h",
-  "git2/global.h",
-  prefix: %w(git_ GIT_ Git))]
+  prefix: %w(git_ GIT_ Git),
+  import_docstrings: "brief",
+)]
 @[Link("git2")]
 lib LibGit2
 end

--- a/shard.lock
+++ b/shard.lock
@@ -2,5 +2,5 @@ version: 1.0
 shards:
   clang:
     github: crystal-lang/clang.cr
-    commit: 1e1003c76d1c37ba123a248757592f65ed8a8c29
+    commit: d019b9ff105cd652f31cca73e950adbf41037d52
 

--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -248,5 +248,57 @@ describe Parser do
       var.name.should eq("tester")
       var.type.should eq(FunctionType.new([PrimitiveType.float, PrimitiveType.char] of Type, PrimitiveType.int))
     end
+
+    it "parses single line brief comments" do
+      source = <<-EOS
+        /// some comment
+        ///
+        /// some other comment
+        int some_func(float x);
+      EOS
+      nodes = parse(source, options: Parser::Option::ImportBriefComments)
+      var = nodes.last.as(Function)
+      var.doc.should eq("some comment")
+    end
+
+    it "parses single line full comments" do
+      source = <<-EOS
+        //! some comment
+        //!
+        //! some other comment
+        int some_func(float x);
+      EOS
+      nodes = parse(source, options: Parser::Option::ImportFullComments)
+      var = nodes.last.as(Function)
+      var.doc.should eq("some comment\n\nsome other comment")
+    end
+
+    it "parses javadoc line brief comments" do
+      source = <<-EOS
+        /**
+           some comment
+
+           some other comment
+         */
+        int some_func(float x);
+      EOS
+      nodes = parse(source, options: Parser::Option::ImportBriefComments)
+      var = nodes.last.as(Function)
+      var.doc.should eq("some comment")
+    end
+
+    it "parses single line full comments" do
+      source = <<-EOS
+        /*!
+         * some comment
+         *
+         * some other comment
+         */
+        int some_func(float x);
+      EOS
+      nodes = parse(source, options: Parser::Option::ImportFullComments)
+      var = nodes.last.as(Function)
+      var.doc.should eq("some comment\n\nsome other comment")
+    end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,6 +3,6 @@ require "../src/crystal_lib"
 
 include CrystalLib
 
-def parse(source)
-  Parser.parse(source)
+def parse(source, flags = [] of String, options = Parser::Option::None)
+  Parser.parse(source, flags, options)
 end

--- a/src/crystal_lib/ast.cr
+++ b/src/crystal_lib/ast.cr
@@ -1,5 +1,7 @@
 module CrystalLib
   abstract class ASTNode
+    property doc : String?
+
     def unscoped_name
       name
     end

--- a/src/crystal_lib/lib_body_transformer.cr
+++ b/src/crystal_lib/lib_body_transformer.cr
@@ -16,6 +16,8 @@ class CrystalLib::LibBodyTransformer < Crystal::Transformer
 
     raise "can't find function #{name}" unless func.is_a?(CrystalLib::Function)
 
+    node.doc = func.doc
+
     node.args = func.args.map_with_index do |arg, i|
       Crystal::Arg.new(arg.name.empty? ? "x#{i}" : @mapper.crystal_arg_name(arg.name), restriction: map_type(arg.type))
     end
@@ -47,6 +49,8 @@ class CrystalLib::LibBodyTransformer < Crystal::Transformer
       value = "0o#{value[1..-1]}"
     end
 
+    node.doc = match.doc
+
     begin
       node.value = Crystal::Parser.parse(value)
     rescue ex : Crystal::Exception
@@ -70,6 +74,8 @@ class CrystalLib::LibBodyTransformer < Crystal::Transformer
 
     match = find_node(name)
     raise "can't find variable #{name}" unless match.is_a?(CrystalLib::Var)
+
+    node.doc = match.doc
 
     node.type_spec = map_type(match.type)
     check_pending_definitions(node)

--- a/src/crystal_lib/prefix_importer.cr
+++ b/src/crystal_lib/prefix_importer.cr
@@ -25,14 +25,14 @@ class CrystalLib::PrefixImporter
     end
 
     name = Crystal::Path.new(name.upcase)
-    @nodes << Crystal::Assign.new(name, value)
+    @nodes << Crystal::Assign.new(name, value).tap(&.doc = node.doc)
   end
 
   def process(node : Var)
     name = match_prefix(node)
     return unless name
 
-    @nodes << Crystal::ExternalVar.new(name, @mapper.map(node.type))
+    @nodes << Crystal::ExternalVar.new(name, @mapper.map(node.type)).tap(&.doc = node.doc)
 
     check_pending_definitions
   end
@@ -50,7 +50,7 @@ class CrystalLib::PrefixImporter
 
     varargs = node.variadic?
 
-    @nodes << Crystal::FunDef.new(name, args, return_type, varargs, real_name: node.name)
+    @nodes << Crystal::FunDef.new(name, args, return_type, varargs, real_name: node.name).tap(&.doc = node.doc)
 
     check_pending_definitions
   end
@@ -61,7 +61,7 @@ class CrystalLib::PrefixImporter
         name = match_prefix(value)
         next unless name
 
-        @nodes << Crystal::Assign.new(Crystal::Path.new(@mapper.crystal_type_name(name)), Crystal::NumberLiteral.new(value.value))
+        @nodes << Crystal::Assign.new(Crystal::Path.new(@mapper.crystal_type_name(name)), Crystal::NumberLiteral.new(value.value)).tap(&.doc = value.doc)
       end
     end
   end

--- a/src/main.cr
+++ b/src/main.cr
@@ -3,4 +3,4 @@ require "./crystal_lib"
 node = Crystal::Parser.parse(ARGF.gets_to_end)
 visitor = CrystalLib::LibTransformer.new
 transformed = node.transform visitor
-puts transformed
+transformed.to_s(STDOUT, emit_doc: true)


### PR DESCRIPTION
This change introduces a new option  to import C doctrings comments at
parsing time. It also introduce a new "import_docstrings" parameter to
import C doctrings as Crystal comments when generating a lib.

This parameter can take two values: "brief" to extract the brief part of
doctrings or "full" to extract the whole docstring <sup>[1](http://www.doxygen.nl/manual/docblocks.html),[2](https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html)</sup>.

A bunch of changes have been made to the core lib to make it possible:
- an Option enum has been added to CrystalLib::Parser
- an @options attribute has been added to CrystalLib::Parser
- a @doc attribute has been added to CrystalLib::AST nodes