### PR TITLE
Fix failing error when encountering Complex number type

### DIFF
--- a/src/crystal_lib/parser.cr
+++ b/src/crystal_lib/parser.cr
@@ -262,7 +262,8 @@ class CrystalLib::Parser
          Clang::TypeKind::Float,
          Clang::TypeKind::Double,
          Clang::TypeKind::LongDouble,
-         Clang::TypeKind::WChar
+         Clang::TypeKind::WChar,
+         Clang::TypeKind::Complex
       primitive_type(type.kind)
     when Clang::TypeKind::Record,
          Clang::TypeKind::Dependent,


### PR DESCRIPTION
I was experimenting with building a shared library from Golang and using `crystal_lib` to generate the bindings.

It failed on `_Complex` type from the Golang generated header file (https://gist.github.com/zph/002dddd6e639ed55583968ddfa306431#file-nautilus-h-L47).

After this patch to crystal_lib, it was able to generate the following successfully:

```crystal
@[Link(ldflags: "./nautilus.o")]
lib LibNautilus
  fun hello = SayHello(p0 : GoString)
  struct X_GoString
    p : LibC::Char*
    n : PtrdiffT
  end
  alias GoString = X_GoString
  alias PtrdiffT = LibC::Long
  fun bye = SayBye
end
```

Thanks for this experimental library and the continued work 👍 