### PR TITLE
Fix issue with anon union in generated code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .crystal/
+/lib

--- a/src/crystal_lib/type_mapper.cr
+++ b/src/crystal_lib/type_mapper.cr
@@ -12,6 +12,7 @@ class CrystalLib::TypeMapper
     @pending_definitions = [] of Crystal::ASTNode
     @pending_structs = [] of PendingStruct
     @generated = {} of UInt64 => Crystal::ASTNode
+    @anon_count = 0
 
     # When completing a struct's fields we keep that struct and the field name in
     # case we find a nested struct, such as in:#
@@ -228,7 +229,7 @@ class CrystalLib::TypeMapper
       return "#{pending_struct.original_name}_#{name}"
     end
 
-    raise "Bug: missing struct name"
+    "anon_#{@anon_count += 1}"
   end
 
   def declare_alias(name, type)


### PR DESCRIPTION
Ok I still don't completely understand the root cause of this issue, but I documented my discovery in olbat/libgen#59. Basically in trying to generate bindings for `ruby.h` I was running into an issue where I was getting the error `Bug: missing struct name`. I eventually tracked the error to [this line](https://github.com/ruby/ruby/blob/v2_7_1/include/ruby/intern.h#L1108) and [this line](https://github.com/ruby/ruby/blob/v2_7_1/include/ruby/intern.h#L1137) in `ruby/intern.h` where there is an anonymous union inside some generated code. In trying to generate a Crystal type for the anonymous union it threw an error because there was no name to assign the type to.

So I did something simple that could probably be improved upon, and added a counter, removed the `raise` call that was causing things to break, and if all the other conditions in `TypeMapper#check_anonymous_name` fail, it returns a generated name `anon_#{@anon_count += 1}`. So now instead of breaking it gives that union a crystal type name `Anon1`.

Let me know if there is anything I can do to improve this, but I personally see it as an acceptable solution. This looks like an edge case that probably won't pop up much. I couldn't even figure out how to reproduce the bug for the specs.