### PR TITLE
Update Crystal dependency declaration in shards.yml to support Crystal 1.x

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -1,6 +1,6 @@
-version: 1.0
+version: 2.0
 shards:
   clang:
-    github: crystal-lang/clang.cr
-    commit: d019b9ff105cd652f31cca73e950adbf41037d52
+    git: https://github.com/crystal-lang/clang.cr.git
+    version: 0.3.0+git.commit.f046ff9e56344e19a2628403eaaea0d6d25ad1d6
 

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.1.0
 description: |
   Automatic binding generator for native libraries in Crystal
 
-crystal: 0.36.0
+crystal: ">= 0.36.0, < 2.0.0"
 
 dependencies:
   clang:


### PR DESCRIPTION
Tests are running ok with Crystal 1.x but CI is broken.