### PR TITLE
`crystal tool format` with Crystal 1.15.0-dev

### DIFF
--- a/examples/llvm.cr
+++ b/examples/llvm.cr
@@ -7,7 +7,7 @@
   "llvm-c/Initialization.h",
   flags: "-I/usr/local/Cellar/llvm/3.6.2/include  -fPIC -fvisibility-inlines-hidden -Wall -W -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wcovered-switch-default -Wnon-virtual-dtor -std=c++11   -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS",
   prefix: %w(LLVM_ LLVM)
-  )]
+)]
 @[Link("stdc++")]
 @[Link(ldflags: "`(llvm-config-3.6 --libs --system-libs --ldflags 2> /dev/null) || (llvm-config-3.5 --libs --system-libs --ldflags 2> /dev/null) || (llvm-config --libs --system-libs --ldflags 2>/dev/null)`")]
 lib LibLLVM


### PR DESCRIPTION
Crystal nightly has a couple new formatter rules enabled: https://github.com/crystal-lang/crystal/pull/14718
The changes are backwards-compatible, so Crystal 1.14.0 won't complain about the new format.